### PR TITLE
Make the kind field owned by types

### DIFF
--- a/src/algorithm/ed25519.rs
+++ b/src/algorithm/ed25519.rs
@@ -75,7 +75,7 @@ impl Seed for SeedEd25519 {
 
         let raw_pub = key_pair.public_key().as_ref().to_vec();
 
-        let kind = &Ed25519;
+        let kind = Ed25519;
 
         Ok((
             PrivateKey {

--- a/src/algorithm/secp256k1.rs
+++ b/src/algorithm/secp256k1.rs
@@ -94,7 +94,7 @@ impl Seed for SeedEcDsaSecP256K1 {
         let public_key = SecPublicKey::from_secret_key(&private_key);
         let public_key_bytes = public_key.serialize_compressed();
 
-        let kind = &Secp256k1;
+        let kind = Secp256k1;
 
         Ok((
             PrivateKey {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,7 @@ pub enum Entropy {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Seed {
     entropy: EntropyArray,
-    kind: &'static Algorithm,
+    kind: Algorithm,
 }
 
 impl Seed {
@@ -139,7 +139,7 @@ impl Seed {
     ///
     /// Panics only if something goes wrong with the random generator
     /// when using the [`Entropy::Random`] parameter.
-    pub fn new(entropy: Entropy, kind: &'static Algorithm) -> Self {
+    pub fn new(entropy: Entropy, kind: Algorithm) -> Self {
         let entropy = match entropy {
             Array(entropy) => entropy,
 
@@ -172,7 +172,7 @@ impl Seed {
     /// assert_ne!(Seed::random(), Seed::random());
     /// ```
     pub fn random() -> Self {
-        Self::new(Random, &Secp256k1)
+        Self::new(Random, Secp256k1)
     }
 
     /// Derive a public and private key from a seed
@@ -252,7 +252,7 @@ impl Seed {
     ///
     /// This method is used in [`AsRef`] trait.
     pub fn as_kind(&self) -> &Algorithm {
-        self.kind
+        &self.kind
     }
 
     fn method(&self) -> &'static dyn alg::Seed {
@@ -275,7 +275,7 @@ impl FromStr for Seed {
     fn from_str(s: &str) -> error::Result<Self> {
         let (entropy, kind) = codec::decode_seed(s).map_err(|_| error::DecodeError)?;
 
-        Ok(Self::new(Array(entropy), kind))
+        Ok(Self::new(Array(entropy), *kind))
     }
 }
 
@@ -323,7 +323,7 @@ impl Signature for HexBytes {}
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct PrivateKey {
     bytes: Vec<u8>,
-    kind: &'static Algorithm,
+    kind: Algorithm,
 }
 
 impl PrivateKey {
@@ -385,7 +385,7 @@ impl fmt::Display for PrivateKey {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct PublicKey {
     bytes: Vec<u8>,
-    kind: &'static Algorithm,
+    kind: Algorithm,
 }
 
 impl PublicKey {

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -58,7 +58,7 @@ mod secp256k1 {
 
     #[test]
     fn new_seed() {
-        let seed = Seed::new(Array(TEST_SECP256K1.entropy), &Secp256k1);
+        let seed = Seed::new(Array(TEST_SECP256K1.entropy), Secp256k1);
 
         assert_eq!(TEST_SECP256K1.seed, seed.to_string());
     }
@@ -151,7 +151,7 @@ mod secp256k1 {
 
     #[test]
     fn random_address() {
-        let random_seed = Seed::new(Random, &Secp256k1);
+        let random_seed = Seed::new(Random, Secp256k1);
         let (_, public) = random_seed.derive_keypair().unwrap();
         let address = public.derive_address();
 
@@ -164,14 +164,14 @@ mod ed25519 {
 
     #[test]
     fn new_seed() {
-        let seed = Seed::new(Array(TEST_ED25519.entropy), &Ed25519);
+        let seed = Seed::new(Array(TEST_ED25519.entropy), Ed25519);
 
         assert_eq!(TEST_ED25519.seed, seed.to_string());
     }
 
     #[test]
     fn random_seed_starts_with_sed() {
-        let seed = Seed::new(Random, &Ed25519);
+        let seed = Seed::new(Random, Ed25519);
 
         assert!(seed.to_string().starts_with("sEd"));
     }
@@ -179,14 +179,14 @@ mod ed25519 {
     #[test]
     fn random_seed() {
         assert_ne!(
-            Seed::new(Random, &Ed25519).to_string(),
-            Seed::new(Random, &Ed25519).to_string()
+            Seed::new(Random, Ed25519).to_string(),
+            Seed::new(Random, Ed25519).to_string()
         );
     }
 
     #[test]
     fn parse_random_seed() {
-        let random_seed = Seed::new(Random, &Ed25519);
+        let random_seed = Seed::new(Random, Ed25519);
         let parsed_seed: Seed = random_seed.to_string().parse().unwrap();
 
         assert_eq!(parsed_seed.as_kind(), random_seed.as_kind());
@@ -263,7 +263,7 @@ mod ed25519 {
 
     #[test]
     fn random_address() {
-        let random_seed = Seed::new(Random, &Ed25519);
+        let random_seed = Seed::new(Random, Ed25519);
         let (_, public) = random_seed.derive_keypair().unwrap();
         let address = public.derive_address();
 


### PR DESCRIPTION
Let the kind field be owned. This makes the users life much easier.